### PR TITLE
重構類型定義

### DIFF
--- a/src/components/MapComponents/AreaLayer.tsx
+++ b/src/components/MapComponents/AreaLayer.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Polygon, Popup } from 'react-leaflet';
 import type { PolygonLayerProps } from '../../types';
 

--- a/src/components/MapComponents/AreaLayer.tsx
+++ b/src/components/MapComponents/AreaLayer.tsx
@@ -1,11 +1,5 @@
 import { Polygon, Popup } from 'react-leaflet';
-
-type LatLngTuple = [number, number];
-
-interface PolygonLayerProps {
-  positions: LatLngTuple[];
-  popupContent?: string;
-}
+import type { PolygonLayerProps } from '../../types';
 
 const AreaLayer: React.FC<PolygonLayerProps> = ({ positions, popupContent }) => {
   return (

--- a/src/components/MapComponents/ZoomHandler.tsx
+++ b/src/components/MapComponents/ZoomHandler.tsx
@@ -1,13 +1,13 @@
+import React from 'react';
 import { useMapEvent } from 'react-leaflet';
 import type { ZoomHandlerProps } from '../../types';
 
-
 const ZoomHandler: React.FC<ZoomHandlerProps> = ({ onZoomChange }) => {
-	useMapEvent('zoomend', (e) => {
-		onZoomChange(e.target.getZoom());
-	});
+    useMapEvent('zoomend', (e) => {
+        onZoomChange(e.target.getZoom());
+    });
 
-	return null;
+    return null;
 };
 
 export default ZoomHandler;

--- a/src/components/MapComponents/ZoomHandler.tsx
+++ b/src/components/MapComponents/ZoomHandler.tsx
@@ -1,15 +1,13 @@
 import { useMapEvent } from 'react-leaflet';
+import type { ZoomHandlerProps } from '../../types';
 
-interface ZoomHandlerProps {
-  onZoomChange: (zoom: number) => void;
-}
 
 const ZoomHandler: React.FC<ZoomHandlerProps> = ({ onZoomChange }) => {
-  useMapEvent('zoomend', (e) => {
-    onZoomChange(e.target.getZoom());
-  });
+	useMapEvent('zoomend', (e) => {
+		onZoomChange(e.target.getZoom());
+	});
 
-  return null;
+	return null;
 };
 
 export default ZoomHandler;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,39 +1,39 @@
 export type LatLng = [number, number];
 
 export interface Area {
-	area_id: number;
-	area_name: string;
-	boundary: {
-		type: string;
-		coordinates: number[][][];
-	};
-	circle: {
-		center: LatLng;
-		radius: number;
-	};
-	devices?: Device[];
+    area_id: number;
+    area_name: string;
+    boundary: {
+        type: string;
+        coordinates: number[][][];
+    };
+    circle: {
+        center: LatLng;
+        radius: number;
+    };
+    devices?: Device[];
 }
 
 export interface Device {
-	device_id: number;
-	device_name: string;
-	area_id: number;
-	latitude: number;
-	longitude: number;
-	location_description?: string;
-	status: string;
+    device_id: number;
+    device_name: string;
+    area_id: number;
+    latitude: number;
+    longitude: number;
+    location_description?: string;
+    status: string;
 }
 
 export interface MapCenter {
-	lat: number;
-	lng: number;
+    lat: number;
+    lng: number;
 }
 
 export interface PolygonLayerProps {
-	positions: [number, number][];
-	popupContent?: string;
+    positions: [number, number][];
+    popupContent?: string;
 }
 
 export interface ZoomHandlerProps {
-	onZoomChange: (zoom: number) => void;
+    onZoomChange: (zoom: number) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,30 +1,39 @@
 export type LatLng = [number, number];
 
 export interface Area {
-  area_id: number;
-  area_name: string;
-  boundary: {
-    type: string;
-    coordinates: number[][][];
-  };
-  circle: {
-    center: LatLng;
-    radius: number;
-  };
-  devices?: Device[];
+	area_id: number;
+	area_name: string;
+	boundary: {
+		type: string;
+		coordinates: number[][][];
+	};
+	circle: {
+		center: LatLng;
+		radius: number;
+	};
+	devices?: Device[];
 }
 
 export interface Device {
-  device_id: number;
-  device_name: string;
-  area_id: number;
-  latitude: number;
-  longitude: number;
-  location_description?: string;
-  status: string;
+	device_id: number;
+	device_name: string;
+	area_id: number;
+	latitude: number;
+	longitude: number;
+	location_description?: string;
+	status: string;
 }
 
 export interface MapCenter {
-  lat: number;
-  lng: number;
+	lat: number;
+	lng: number;
+}
+
+export interface PolygonLayerProps {
+	positions: [number, number][];
+	popupContent?: string;
+}
+
+export interface ZoomHandlerProps {
+	onZoomChange: (zoom: number) => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface MapCenter {
 }
 
 export interface PolygonLayerProps {
-    positions: [number, number][];
+    positions: LatLng[];
     popupContent?: string;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor type definitions by centralizing component prop interfaces into the shared types file, standardizing formatting, and updating imports

Enhancements:
- Consolidate PolygonLayerProps and ZoomHandlerProps into src/types.ts and import them in their respective components
- Reformat existing Area, Device, and MapCenter types for consistent indentation
- Remove inline component prop interface declarations and ensure components import React and use centralized types